### PR TITLE
fix: align extension manifest to company standards

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,15 +1,15 @@
 {
   "manifestVersion": 1,
-  "id": "dsv-azure-pipelines-task",
-  "name": "Azure DevOps Delinea DevOps Secret vault plugin",
+  "id": "delinea-dsv-task",
+  "name": "Delinea DSV Azure DevOps Task",
   "version": "0.0.1",
-  "publisher": "DelineaXPM",
+  "publisher": "Delinea",
   "targets": [
     {
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "description": "Azure DevOps Delinea DevOps Secret vault plugin for secure secrets retrieval in Azure Pipelines",
+  "description": "Azure DevOps task for accessing secrets from Delinea DSV",
   "categories": ["Azure Pipelines"],
   "icons": {
     "default": "images/delinea-icon-devops-secrets-vault.png"


### PR DESCRIPTION
Align extension manifest with what already published for Secret Server:
```
[dsv] "id": "delinea-dsv-task"
[ss]  "id": "delinea-ss-task"
---
[dsv] "name": "Delinea DSV Azure DevOps Task"
[ss]  "name": "Delinea Secret Server Azure DevOps Task"
---
[dsv] "description": "Azure DevOps task for accessing secrets from Delinea DSV"
[ss]  "description": "Azure DevOps task for accessing secrets from Delinea Secret Server"
```

Also fix publisher name: [Delinea](https://marketplace.visualstudio.com/publishers/Delinea)